### PR TITLE
chore(githubactions): adding repository_dispatch events for deployment

### DIFF
--- a/.github/workflows/deploy-ibm-cloud-staging.yml
+++ b/.github/workflows/deploy-ibm-cloud-staging.yml
@@ -1,0 +1,32 @@
+name: deploy (Deploy to IBM Cloud Staging)
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn install
+      - name: Grab latest next release
+        run: yarn update-next
+      - name: Build project
+        run: yarn build
+      - name: Deploying to IBM Cloud (Staging)
+        uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
+        with:
+          cloud-api-key: ${{ secrets.CLOUD_API_KEY }}
+          cf-org: ibm-digital-design
+          cf-space: ibmdotcom-production
+          cf-region: us-south
+          cf-app: ibmdotcom-web-components-html-staging
+          cf-manifest: manifest-staging.yml
+          deploy-dir: ./

--- a/.github/workflows/deploy-ibm-cloud.yml
+++ b/.github/workflows/deploy-ibm-cloud.yml
@@ -1,9 +1,11 @@
-name: deploy (Deploy to IBM Cloud)
+name: deploy (Deploy to IBM Cloud Canary)
 
 on:
   push:
     branches:
       - master
+  repository_dispatch:
+    types: [deploy-canary]
 
 jobs:
   deploy-canary:
@@ -20,7 +22,7 @@ jobs:
         run: yarn update-canary
       - name: Build project
         run: yarn build
-      - name: Deploying to IBM Cloud
+      - name: Deploying to IBM Cloud (Canary)
         uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
         with:
           cloud-api-key: ${{ secrets.CLOUD_API_KEY }}
@@ -50,7 +52,7 @@ jobs:
           ENABLE_RTL: true
       - name: Build project
         run: yarn build
-      - name: Deploying to IBM Cloud
+      - name: Deploying to IBM Cloud (Canary - RTL)
         uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
         with:
           cloud-api-key: ${{ secrets.CLOUD_API_KEY }}
@@ -59,28 +61,4 @@ jobs:
           cf-region: us-south
           cf-app: ibmdotcom-web-components-html-rtl
           cf-manifest: manifest-rtl.yml
-          deploy-dir: ./
-  deploy-staging:
-    runs-on: ubuntu-16.04
-    steps:
-      - uses: actions/checkout@master
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Install dependencies
-        run: yarn install
-      - name: Grab latest next release
-        run: yarn update-next
-      - name: Build project
-        run: yarn build
-      - name: Deploying to IBM Cloud
-        uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
-        with:
-          cloud-api-key: ${{ secrets.CLOUD_API_KEY }}
-          cf-org: ibm-digital-design
-          cf-space: ibmdotcom-production
-          cf-region: us-south
-          cf-app: ibmdotcom-web-components-html-staging
-          cf-manifest: manifest-staging.yml
           deploy-dir: ./

--- a/scripts/deploy_preview_comment.js
+++ b/scripts/deploy_preview_comment.js
@@ -22,7 +22,8 @@ const botUser = 'ibmdotcom-bot';
  *
  * @type {string}
  */
-const repoSlug = 'carbon-design-system/ibmdotcom-web-components-test';
+const repoSlug =
+  'carbon-design-system/carbon-for-ibm-dotcom-web-components-test';
 
 /**
  * Github host


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This adds a repository_dispatch event for this repo to trigger
deployments when NPM canary releases are created

This is an effort to remove these jobs in our other CI builder.

### Changelog

**New**

- `repository_dispatch` event for triggering canary/test builds

**Changed**

- Moved staging builds into its own workflow so it doesn't get triggered by dispatch events

