### PR TITLE
chore(dotcom-shell): suppress page until custom elements are defined

### DIFF
--- a/src/layouts/base.hbs
+++ b/src/layouts/base.hbs
@@ -192,6 +192,13 @@
       {{/if}}
   </script>
 
+  <!-- Suppress custom elements until styles are loaded -->
+  <style>
+    dds-dotcom-shell-container:not(:defined) {
+      display: none;
+    }
+  </style>
+
   <!-- IBM Tag Management and Site Analytics -->
   <script src="//1.www.s81c.com/common/stats/ibm-common.js" defer></script>
 </head>


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This will temporarily suppress unstyled custom elements until the page
is fully loaded.

### Changelog

**Changed**

- New `:not(:defined)` style for dotcom shell