### PR TITLE
fix(webpack): multiple fixes to page chunk handling

### DIFF
--- a/config/webpack.config-helper.js
+++ b/config/webpack.config-helper.js
@@ -24,9 +24,11 @@ for (let i = 0; i < pages.length; i++) {
   let page = Object.assign({}, pages[i]);
   renderedPages.push(
     new HtmlWebpackPlugin({
+      hash: true,
+      inject: true,
       template: page.template,
       filename: page.output,
-      chunks: ['global', ...page.chunks],
+      chunks: page.chunks,
       title: page.content.title,
       description: page.content.description,
       altlangRootPath:
@@ -42,16 +44,10 @@ module.exports = (options) => {
 
   let webpackConfig = {
     devtool: options.devtool,
-    entry: Object.assign(
-      {},
-      {
-        global: './src/pages/global.js',
-      },
-      chunkEntries
-    ),
+    entry: chunkEntries,
     output: {
       path: dest,
-      filename: './assets/js/[name].[hash].js',
+      filename: './assets/js/[name].js',
     },
     plugins: [
       new CopyWebpackPlugin([
@@ -61,7 +57,7 @@ module.exports = (options) => {
       //   {from: './src/assets/fonts', to: './assets/fonts'}
       // ]),
       new MiniCssExtractPlugin({
-        filename: './assets/css/[name].[contenthash].css',
+        filename: './assets/css/[name].css',
       }),
       new Webpack.DefinePlugin({
         'process.env': JSON.stringify(
@@ -117,6 +113,9 @@ module.exports = (options) => {
 
   webpackConfig.optimization = {
     ...webpackConfig.optimization,
+    splitChunks: {
+      chunks: 'all',
+    },
     minimizer: [
       new TerserPlugin({
         sourceMap: options.isProduction,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "clean": "rimraf dist",
     "build": "webpack --config ./config/webpack-prod.config.js --colors --optimize-minimize",
     "start": "webpack-dev-server --config ./config/webpack-dev.config.js --watch --colors -d",
     "lint": "eslint src",
@@ -38,7 +39,7 @@
     "file-loader": "^1.1.11",
     "handlebars": "^4.0.12",
     "handlebars-loader": "^1.7.0",
-    "html-webpack-plugin": "^3.2.0",
+    "html-webpack-plugin": "^4.5.1",
     "husky": "^4.3.0",
     "lint-staged": "^10.4.0",
     "mini-css-extract-plugin": "^0.11.0",
@@ -56,7 +57,7 @@
   },
   "dependencies": {
     "@carbon/grid": "^10.15.0",
-    "@carbon/ibmdotcom-web-components": "^1.0.0-canary.499866680.0",
+    "@carbon/ibmdotcom-web-components": "^1.0.0",
     "@carbon/type": "^10.13.0",
     "carbon-web-components": "^1.7.1",
     "lit-element": "^2.4.0",

--- a/src/pages.js
+++ b/src/pages.js
@@ -43,7 +43,7 @@ const pages = [
       description: 'Solutions template',
     },
     chunkEntry: {
-      learn: './src/pages/solutions/solutions.js',
+      solutions: './src/pages/solutions/solutions.js',
     },
     template: './src/pages/solutions/solutions.hbs',
   },

--- a/src/pages/global.js
+++ b/src/pages/global.js
@@ -1,8 +1,6 @@
 import '@carbon/ibmdotcom-web-components/es/components/dotcom-shell/dotcom-shell-container.js';
 import '../assets/scss/app.scss';
 
-// TODO: separate chunks loaded do not seem to render for some reason, need to investigate this, but adding all artifacts here for now
-
 // Button Group
 import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group.js';
 import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item.js';
@@ -13,61 +11,11 @@ import '@carbon/ibmdotcom-web-components/es/components/card/card-eyebrow.js';
 import '@carbon/ibmdotcom-web-components/es/components/card/card-heading.js';
 import '@carbon/ibmdotcom-web-components/es/components/card/card-footer.js';
 
-// Card Group
-import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group.js';
-import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item.js';
-import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link.js';
-
-// Card Section
-import '@carbon/ibmdotcom-web-components/es/components/card-section-images/card-section-images.js';
-import '@carbon/ibmdotcom-web-components/es/components/card-section-simple/card-section-simple.js';
-
-// Callout
-import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data.js';
-import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data-source.js';
-import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data-copy.js';
-
-import '@carbon/ibmdotcom-web-components/es/components/callout-quote/callout-quote.js';
-import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media.js';
-import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media-video.js';
-
-// Content Block Cards
-import '@carbon/ibmdotcom-web-components/es/components/content-block-cards/content-block-cards.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-copy.js';
-
-// Content Block
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-complementary.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-paragraph.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-copy.js';
-
-// Content Block variations
-import '@carbon/ibmdotcom-web-components/es/components/content-block-mixed/content-block-mixed.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media-content.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block-simple/content-block-simple.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented/content-block-segmented.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented/content-block-segmented-item.js';
-
 // Content Group Cards
 import '@carbon/ibmdotcom-web-components/es/components/content-group/content-group-heading.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-group/content-group-copy.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-group-cards/content-group-cards.js';
 import '@carbon/ibmdotcom-web-components/es/components/content-group-cards/content-group-cards-item.js';
-
-// Content Group and Horizontal
-import '@carbon/ibmdotcom-web-components/es/components/content-group-horizontal/content-group-horizontal.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-item-horizontal/content-item-horizontal.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-item-horizontal/content-item-horizontal-eyebrow.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-item-horizontal/content-item-horizontal-copy.js';
-
-import '@carbon/ibmdotcom-web-components/es/components/content-group-pictograms/content-group-pictograms.js';
-import '@carbon/ibmdotcom-web-components/es/components/content-group-simple/content-group-simple.js';
-
-import '@carbon/ibmdotcom-web-components/es/components/content-section/content-section-heading.js';
 
 // CTA
 import '@carbon/ibmdotcom-web-components/es/components/cta/card-cta.js';
@@ -76,25 +24,12 @@ import '@carbon/ibmdotcom-web-components/es/components/cta/feature-cta-footer.js
 import '@carbon/ibmdotcom-web-components/es/components/cta/text-cta.js';
 import '@carbon/ibmdotcom-web-components/es/components/cta/video-cta-container.js';
 
-// CTA Section
-import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section.js';
-import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-copy.js';
-import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item.js';
-import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item-copy.js';
-
 // Feature Card
 import '@carbon/ibmdotcom-web-components/es/components/feature-card/feature-card.js';
 import '@carbon/ibmdotcom-web-components/es/components/feature-card/feature-card-footer.js';
 
 import '@carbon/ibmdotcom-web-components/es/components/feature-card-block-large/feature-card-block-large.js';
 import '@carbon/ibmdotcom-web-components/es/components/feature-card-block-large/feature-card-block-large-footer.js';
-
-import '@carbon/ibmdotcom-web-components/es/components/horizontal-rule/horizontal-rule.js';
-
-// Image
-import '@carbon/ibmdotcom-web-components/es/components/image/image.js';
-import '@carbon/ibmdotcom-web-components/es/components/image-with-caption/image-with-caption.js';
 
 // Link List
 import '@carbon/ibmdotcom-web-components/es/components/link-list/link-list.js';
@@ -105,28 +40,6 @@ import '@carbon/ibmdotcom-web-components/es/components/cta/link-list-item-cta.js
 
 import '@carbon/ibmdotcom-web-components/es/components/link-with-icon/link-with-icon';
 
-// Leadspace
-import '@carbon/ibmdotcom-web-components/es/components/leadspace/leadspace.js';
-import '@carbon/ibmdotcom-web-components/es/components/leadspace/leadspace-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block.js';
-import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block-content.js';
-import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block-media.js';
-import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block-cta.js';
-
-// Logo Grid
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid.js';
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-item.js';
-import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-link.js';
-
 import '@carbon/ibmdotcom-web-components/es/components/pictogram-item/pictogram-item.js';
-
-// Quote
-import '@carbon/ibmdotcom-web-components/es/components/quote/quote';
-import '@carbon/ibmdotcom-web-components/es/components/quote/quote-source-heading.js';
-import '@carbon/ibmdotcom-web-components/es/components/quote/quote-source-copy.js';
-import '@carbon/ibmdotcom-web-components/es/components/quote/quote-source-bottom-copy.js';
-
-import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/table-of-contents.js';
 
 import '@carbon/ibmdotcom-web-components/es/components/video-player/video-player-container.js';

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -1,4 +1,5 @@
-// TODO: separate chunks loaded do not seem to render for some reason, need to investigate this
+import '../global';
+
 import '@carbon/ibmdotcom-web-components/es/components/content-section/content-section-heading.js';
 import '@carbon/ibmdotcom-web-components/es/components/card-section-simple/card-section-simple.js';
 import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group.js';

--- a/src/pages/learn/learn.hbs
+++ b/src/pages/learn/learn.hbs
@@ -1,9 +1,12 @@
 {{#> base }}
 
   <div class="page-container">
-    <dds-leadspace type='centered' alt="Image text" default-src='../assets/images/leadspace-sample-2.jpg'>
+    <dds-leadspace type="centered" alt="Image text" default-src="../assets/images/leadspace-sample-2.jpg">
       <dds-leadspace-heading>Lead space title</dds-leadspace-heading>
       Use this area for a short line of copy to support the title
+
+      <dds-image slot="image" class="bx--image" alt="Alt image text" default-src="../assets/images/leadspace-sample-2.jpg">
+      </dds-image>
     </dds-leadspace>
     <dds-table-of-contents>
       <a name="1" data-title="Content Block - Mixed Groups"></a>
@@ -42,9 +45,9 @@
             <dds-link-list-item-card href="https://example.com" cta-type="external">
               <p>Why should you use microservices and containers</p>
               <dds-card-cta-footer>
-                <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 32 32" class="bx--card__cta dds-ce--cta__icon"><!----><path d="M26,28H6a2.0027,2.0027,0,0,1-2-2V6A2.0027,2.0027,0,0,1,6,4H16V6H6V26H26V16h2V26A2.0027,2.0027,0,0,1,26,28Z"></path><path d="M20 2L20 4 26.586 4 18 12.586 19.414 14 28 5.414 28 12 30 12 30 2 20 2z"></path></svg>
+                <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 32 32" class="bx--card__cta dds-ce--cta__icon">&lt;!&ndash;&ndash;&gt;<path d="M26,28H6a2.0027,2.0027,0,0,1-2-2V6A2.0027,2.0027,0,0,1,6,4H16V6H6V26H26V16h2V26A2.0027,2.0027,0,0,1,26,28Z"></path><path d="M20 2L20 4 26.586 4 18 12.586 19.414 14 28 5.414 28 12 30 12 30 2 20 2z"></path></svg>
               </dds-card-cta-footer>
-            </dds-link-list-item-card-cta>
+            </dds-link-list-item-card>
           </dds-link-list>
         </dds-content-block-complementary>
 
@@ -59,7 +62,7 @@
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
             </p>
             <dds-card-footer icon-placement="left">
-              <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon"><!----><path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
+              <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">&lt;!&ndash;&ndash;&gt;<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
             </dds-card-footer>
           </dds-content-group-cards-item>
 
@@ -71,7 +74,7 @@
               Lorem ipsum dolor sit amet, consectetur adipiscing elit
             </p>
             <dds-card-footer icon-placement="left">
-              <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon"><!----><path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
+              <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">&lt;!&ndash;&ndash;&gt;<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
             </dds-card-footer>
           </dds-content-group-cards-item>
 
@@ -83,7 +86,7 @@
               Lorem ipsum dolor sit amet
             </p>
             <dds-card-footer icon-placement="left">
-              <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon"><!----><path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
+              <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">&lt;!&ndash;&ndash;&gt;<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
             </dds-card-footer>
           </dds-content-group-cards-item>
 
@@ -95,11 +98,11 @@
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
             </p>
             <dds-card-footer icon-placement="left">
-              <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon"><!----><path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
+              <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">&lt;!&ndash;&ndash;&gt;<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
             </dds-card-footer>
           </dds-content-group-cards-item>
         </dds-content-group-cards>
-        
+
         <dds-content-group-pictograms>
           <dds-content-group-heading>Content Group - with Pictograms</dds-content-group-heading>
               <dds-pictogram-item>
@@ -132,7 +135,7 @@
                 <dds-content-item-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero</dds-content-item-copy>
                 <dds-link-with-icon href="http://example.com" slot="footer">
                   Lorem ipsum dolor
-                  <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon"><!----><path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
+                  <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">&lt;!&ndash;&ndash;&gt;<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
                 </dds-link-with-icon>
               </dds-pictogram-item>
 
@@ -159,7 +162,7 @@
                 <dds-content-item-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero</dds-content-item-copy>
                 <dds-link-with-icon href="http://example.com" slot="footer">
                   Lorem ipsum dolor
-                  <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon"><!----><path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
+                  <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">&lt;!&ndash;&ndash;&gt;<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
                 </dds-link-with-icon>
               </dds-pictogram-item>
 
@@ -185,7 +188,7 @@
                 <dds-content-item-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean et ultricies est. Mauris iaculis eget dolor nec hendrerit. Phasellus at elit sollicitudin, sodales nulla quis, consequat libero</dds-content-item-copy>
                 <dds-link-with-icon href="http://example.com" slot="footer">
                   Lorem ipsum dolor
-                  <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon"><!----><path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
+                  <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">&lt;!&ndash;&ndash;&gt;<path d="M11.8 2.8L10.8 3.8 16.2 9.3 1 9.3 1 10.7 16.2 10.7 10.8 16.2 11.8 17.2 19 10z"></path></svg>
                 </dds-link-with-icon>
               </dds-pictogram-item>
           </dds-content-group-pictograms>
@@ -200,7 +203,7 @@
               <dds-content-item-heading>Lorem ipsum dolor sit amet.</dds-content-item-heading>
               <dds-content-item-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</dds-content-item-copy>
             </dds-content-item>
-            
+
             <dds-content-item>
               <dds-content-item-heading>Lorem ipsum dolor sit amet.</dds-content-item-heading>
               <dds-content-item-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</dds-content-item-copy>
@@ -212,7 +215,7 @@
             </dds-card-cta>
         </dds-content-group-simple>
       </dds-content-block-mixed>
-      
+
       <a name="2" data-title="Content Block - Segmented"></a>
       <div class='bx--grid'>
         <div class="bx--row">
@@ -278,7 +281,7 @@
               <dds-image-with-caption slot="media" alt="Image alt text" default-src="../assets/images/card-sample-5.jpg" heading="Lorem ipsum dolor sit amet.">
                 <dds-image-item media="(min-width: 672px)" srcset="../assets/images/card-sample-5.jpg"> </dds-image-item>
               </dds-image-with-caption>
-              
+
               <dds-content-item>
                 <dds-content-item-heading>Lorem ipsum dolor sit amet.</dds-content-item-heading>
                 <dds-content-item-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</dds-content-item-copy>
@@ -299,7 +302,7 @@
               <dds-image-with-caption slot="media" alt="Image alt text" default-src="../assets/images/card-sample-5.jpg" heading="Lorem ipsum dolor sit amet.">
                 <dds-image-item media="(min-width: 672px)" srcset="../assets/images/card-sample-5.jpg"> </dds-image-item>
               </dds-image-with-caption>
-              
+
               <dds-content-item>
                 <dds-content-item-heading>Lorem ipsum dolor sit amet.</dds-content-item-heading>
                 <dds-content-item-copy>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.</dds-content-item-copy>
@@ -314,9 +317,10 @@
                 <dds-card-cta-footer></dds-card-cta-footer>
               </dds-card-cta>
             </dds-content-block-media-content>
+          </dds-content-block-media>
           </div>
         </div>
-        
+
         <div class='bx--grid'>
           <div class="bx--row">
             <dds-content-block-media-content>
@@ -349,7 +353,7 @@
     <div class='bx--g10-container'>
       <dds-card-section-images>
         <dds-content-section-heading>Card Section - with Images</dds-content-section-heading>
-        
+
         <dds-card-group>
           <dds-card-group-item href='https://example.com'>
             <dds-image slot='image' alt='Image alt text' default-src='../assets/images/card-sample-1.jpg'></dds-image>
@@ -594,8 +598,6 @@
       </dds-card-section-simple>
     </div>
 
-
-      
-  </div>    
+  </div>
 
 {{/ base }}

--- a/src/pages/learn/learn.js
+++ b/src/pages/learn/learn.js
@@ -1,1 +1,37 @@
+import '../global';
 // All imports come from global.js. Add other specific components here if needed.
+
+// Leadspace
+import '@carbon/ibmdotcom-web-components/es/components/leadspace/leadspace.js';
+import '@carbon/ibmdotcom-web-components/es/components/leadspace/leadspace-heading.js';
+
+// Image
+import '@carbon/ibmdotcom-web-components/es/components/image/image.js';
+
+// Table of Contents
+import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/table-of-contents.js';
+
+// Content Block
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-complementary.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-paragraph.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-copy.js';
+
+// Content Block variations
+import '@carbon/ibmdotcom-web-components/es/components/content-block-mixed/content-block-mixed.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media-content.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-simple/content-block-simple.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented/content-block-segmented.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented/content-block-segmented-item.js';
+
+// Card Section
+import '@carbon/ibmdotcom-web-components/es/components/card-section-images/card-section-images.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-section-simple/card-section-simple.js';
+
+// Card Group
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item.js';
+
+// Horizontal Rule
+import '@carbon/ibmdotcom-web-components/es/components/horizontal-rule/horizontal-rule.js';

--- a/src/pages/services/services.js
+++ b/src/pages/services/services.js
@@ -1,1 +1,69 @@
+import '../global';
 // All imports come from global.js. Add other specific components here if needed.
+
+// Leadspace
+import '@carbon/ibmdotcom-web-components/es/components/leadspace/leadspace.js';
+import '@carbon/ibmdotcom-web-components/es/components/leadspace/leadspace-heading.js';
+
+// Table of Contents
+import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/table-of-contents.js';
+
+// Content Block
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-complementary.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-paragraph.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-copy.js';
+
+// Content Block variations
+import '@carbon/ibmdotcom-web-components/es/components/content-block-mixed/content-block-mixed.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media-content.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-simple/content-block-simple.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented/content-block-segmented.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented/content-block-segmented-item.js';
+
+// Callout Data
+import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data.js';
+import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data-source.js';
+import '@carbon/ibmdotcom-web-components/es/components/callout-data/callout-data-copy.js';
+
+// Callout with media
+import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media.js';
+import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media-video.js';
+
+// Card Group
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link.js';
+
+// Image
+import '@carbon/ibmdotcom-web-components/es/components/image/image.js';
+import '@carbon/ibmdotcom-web-components/es/components/image-with-caption/image-with-caption.js';
+
+// Content Group and Horizontal
+import '@carbon/ibmdotcom-web-components/es/components/content-group-horizontal/content-group-horizontal.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item-horizontal/content-item-horizontal.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item-horizontal/content-item-horizontal-eyebrow.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item-horizontal/content-item-horizontal-copy.js';
+
+import '@carbon/ibmdotcom-web-components/es/components/content-group-pictograms/content-group-pictograms.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-group-simple/content-group-simple.js';
+
+import '@carbon/ibmdotcom-web-components/es/components/content-section/content-section-heading.js';
+
+// Content Block Cards
+import '@carbon/ibmdotcom-web-components/es/components/content-block-cards/content-block-cards.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-item/content-item-copy.js';
+
+// CTA Section
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-copy.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item-copy.js';
+
+// Horizontal Rule
+import '@carbon/ibmdotcom-web-components/es/components/horizontal-rule/horizontal-rule.js';

--- a/src/pages/solutions/solutions.js
+++ b/src/pages/solutions/solutions.js
@@ -1,1 +1,64 @@
+import '../global';
+
 // All imports come from global.js. Add other specific components here if needed.
+
+// Leadspace Block
+import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block.js';
+import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block-content.js';
+import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block-media.js';
+import '@carbon/ibmdotcom-web-components/es/components/leadspace-block/leadspace-block-cta.js';
+
+// Callout Quote
+import '@carbon/ibmdotcom-web-components/es/components/callout-quote/callout-quote.js';
+
+// Card Group
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-group/card-group-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/card-link/card-link.js';
+
+// Callout with media
+import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media.js';
+import '@carbon/ibmdotcom-web-components/es/components/callout-with-media/callout-with-media-video.js';
+
+// Content Block variations
+import '@carbon/ibmdotcom-web-components/es/components/content-block-mixed/content-block-mixed.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-media/content-block-media-content.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-simple/content-block-simple.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented/content-block-segmented.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented/content-block-segmented-item.js';
+
+// Content Block
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-complementary.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-paragraph.js';
+import '@carbon/ibmdotcom-web-components/es/components/content-block/content-block-copy.js';
+
+// Image
+import '@carbon/ibmdotcom-web-components/es/components/image/image.js';
+import '@carbon/ibmdotcom-web-components/es/components/image-with-caption/image-with-caption.js';
+
+// Logo Grid
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid.js';
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/logo-grid/logo-grid-link.js';
+
+// Quote
+import '@carbon/ibmdotcom-web-components/es/components/quote/quote';
+import '@carbon/ibmdotcom-web-components/es/components/quote/quote-source-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/quote/quote-source-copy.js';
+import '@carbon/ibmdotcom-web-components/es/components/quote/quote-source-bottom-copy.js';
+
+// Table of Contents
+import '@carbon/ibmdotcom-web-components/es/components/table-of-contents/table-of-contents.js';
+
+// Horizontal Rule
+import '@carbon/ibmdotcom-web-components/es/components/horizontal-rule/horizontal-rule.js';
+
+// CTA Section
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-copy.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item-heading.js';
+import '@carbon/ibmdotcom-web-components/es/components/cta-section/cta-section-item-copy.js';

--- a/src/pages/ui-components/ui-components.js
+++ b/src/pages/ui-components/ui-components.js
@@ -1,4 +1,4 @@
-// TODO: separate chunks loaded do not seem to render for some reason, need to investigate this
+import '../global';
 
 import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group.js';
 import '@carbon/ibmdotcom-web-components/es/components/button-group/button-group-item.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -930,20 +930,20 @@
     "@carbon/import-once" "^10.3.0"
     "@carbon/layout" "^10.13.0"
 
-"@carbon/ibmdotcom-services@1.15.0-canary.499866680.0+82f5ec0":
-  version "1.15.0-canary.499866680.0"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-services/-/ibmdotcom-services-1.15.0-canary.499866680.0.tgz#9fc712e6700627b2cb6a649d3d45c3cb70ce222e"
-  integrity sha512-Bws2w63NI74hci5tkEmMk2vrcOG7FrntXtpyiL6YXUUItaNz9gduUL/dCjNKfsb/1hMoUyV3noHW5fmdzdqhTQ==
+"@carbon/ibmdotcom-services@1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-services/-/ibmdotcom-services-1.15.0.tgz#fdbf5142b5252672523eb8392d964b893a7832e8"
+  integrity sha512-m4d+yvyInTVBLQfNn4bGPs/oJfHsWlbRB54zBc0+hwQ/TIoelWH6WdMmV9ghOA9F8baQDz9O7UIrQSFGRPLk+g==
   dependencies:
     "@babel/runtime" "^7.5.0"
-    "@carbon/ibmdotcom-utilities" "1.15.0-canary.499866680.0+82f5ec0"
+    "@carbon/ibmdotcom-utilities" "1.15.0"
     axios "^0.21.1"
     window-or-global "^1.0.1"
 
-"@carbon/ibmdotcom-styles@1.15.0-canary.499866680.0+82f5ec0":
-  version "1.15.0-canary.499866680.0"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-styles/-/ibmdotcom-styles-1.15.0-canary.499866680.0.tgz#73894c9c58bae5b933f547a5511a8318a63ae861"
-  integrity sha512-20CxNK/xe0C1iYoQdn8cPH/fD6XYVX9wkVtahteWl74bNf2kS/g6JcpsdR5VOC9kAu0I7ke88GoblWv+r0/cYg==
+"@carbon/ibmdotcom-styles@1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-styles/-/ibmdotcom-styles-1.15.0.tgz#efeb5e97ed9f673b356e08d36381a1430f961f28"
+  integrity sha512-+R+ZVzPAA41eSAlcbNO8UbeEreZedLVLjgjrls1QT9bB7VjJl6JxcytefJamhj2YQkCG+Yv6Ctx4XFxW9pNcaA==
   dependencies:
     "@carbon/grid" "10.18.0"
     "@carbon/icons-react" "10.23.0"
@@ -954,10 +954,10 @@
     "@carbon/type" "10.19.0"
     carbon-components "10.26.0"
 
-"@carbon/ibmdotcom-utilities@1.15.0-canary.499866680.0+82f5ec0":
-  version "1.15.0-canary.499866680.0"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-utilities/-/ibmdotcom-utilities-1.15.0-canary.499866680.0.tgz#0c42abd7e552fa2baf167388ec7452513924b3a2"
-  integrity sha512-W+Gmj5AUgP0WxS6tfpzl34wTTpDIvQ73fEwIKJ049V69fvQwvWIaLPwH9SkXl6O7xWW8EKSMlNo8un0RURbz0Q==
+"@carbon/ibmdotcom-utilities@1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-utilities/-/ibmdotcom-utilities-1.15.0.tgz#9951ed665fb112077687475d8aa25559b789f278"
+  integrity sha512-MJyIz+u0Envnx68L2y3FdCf6/00cOS/FGPeodb6rfMQDR2pwGu1D+587tuq0ucmX7JrDSQYUzvbgfo9MtgA29g==
   dependencies:
     axios "^0.21.1"
     carbon-components "10.26.0"
@@ -966,14 +966,14 @@
     marked "1.1.0"
     window-or-global "^1.0.1"
 
-"@carbon/ibmdotcom-web-components@^1.0.0-canary.499866680.0":
-  version "1.0.0-canary.499866680.0"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-web-components/-/ibmdotcom-web-components-1.0.0-canary.499866680.0.tgz#0bbafc1fe99b6aad8516b6baf7684cf8408d2d5c"
-  integrity sha512-NBw4jmrtsDS92XBOM2u2YQNHXKbXVMtT9bRXWEx5H9lT7M5xeVtLVvfxh4DbbCAtVd0nELOTcqINHEGPWl/icQ==
+"@carbon/ibmdotcom-web-components@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-web-components/-/ibmdotcom-web-components-1.0.0.tgz#24d186c6447977e0f6e1fe55ff7e425902c6f083"
+  integrity sha512-afbNWn87jta2iWSdr0GJOCHAfPPnVuIGxoX7+21DdVyJLOY9gzfiwXSClxILpgwgQcjK68i+8ISyHt2AfoOTCA==
   dependencies:
-    "@carbon/ibmdotcom-services" "1.15.0-canary.499866680.0+82f5ec0"
-    "@carbon/ibmdotcom-styles" "1.15.0-canary.499866680.0+82f5ec0"
-    "@carbon/ibmdotcom-utilities" "1.15.0-canary.499866680.0+82f5ec0"
+    "@carbon/ibmdotcom-services" "1.15.0"
+    "@carbon/ibmdotcom-styles" "1.15.0"
+    "@carbon/ibmdotcom-utilities" "1.15.0"
     "@carbon/layout" "10.16.0"
     carbon-components "10.26.0"
     carbon-web-components "1.11.1"
@@ -1251,6 +1251,11 @@
     remark "^12.0.0"
     unist-util-find-all-after "^3.0.1"
 
+"@types/anymatch@*":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
+  integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1270,6 +1275,11 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/html-minifier-terser@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
+  integrity sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==
 
 "@types/json-schema@^7.0.5":
   version "7.0.5"
@@ -1306,10 +1316,27 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/source-list-map@*":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
+  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/tapable@*", "@types/tapable@^1.0.5":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
+  integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
 "@types/trusted-types@*":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
   integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
+
+"@types/uglify-js@*":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.12.0.tgz#2bb061c269441620d46b946350c8f16d52ef37c5"
+  integrity sha512-sYAF+CF9XZ5cvEBkI7RtrG9g2GtMBkviTnBxYYyq+8BWvO4QtXfwwR6a2LFwCi4evMKZfpv6U43ViYvv17Wz3Q==
+  dependencies:
+    source-map "^0.6.1"
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
@@ -1331,6 +1358,27 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@types/webpack-sources@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz#8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10"
+  integrity sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==
+  dependencies:
+    "@types/node" "*"
+    "@types/source-list-map" "*"
+    source-map "^0.7.3"
+
+"@types/webpack@^4.41.8":
+  version "4.41.26"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.26.tgz#27a30d7d531e16489f9c7607c747be6bc1a459ef"
+  integrity sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    source-map "^0.6.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -2111,7 +2159,7 @@ bonjour@^3.5.0:
     multicast-dns "^6.0.1"
     multicast-dns-service-types "^1.1.0"
 
-boolbase@~1.0.0:
+boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
@@ -2466,13 +2514,13 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camel-case@3.0.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
-  integrity sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
+camel-case@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
   dependencies:
-    no-case "^2.2.0"
-    upper-case "^1.1.1"
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -2692,7 +2740,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clean-css@4.2.x:
+clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
   integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
@@ -2867,15 +2915,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.17.x:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
-
 commander@^2.2.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@^6.0.0, commander@^6.1.0:
   version "6.1.0"
@@ -2886,11 +2934,6 @@ commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
   integrity sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=
-
-commander@~2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 comment-parser@^0.6.2:
   version "0.6.2"
@@ -3252,15 +3295,15 @@ css-loader@^1.0.1:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-select@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
-  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+css-select@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
+  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
   dependencies:
-    boolbase "~1.0.0"
-    css-what "2.1"
-    domutils "1.5.1"
-    nth-check "~1.0.1"
+    boolbase "^1.0.0"
+    css-what "^3.2.1"
+    domutils "^1.7.0"
+    nth-check "^1.0.2"
 
 css-selector-tokenizer@^0.7.0:
   version "0.7.3"
@@ -3270,10 +3313,10 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^3.0.0"
     fastparse "^1.1.2"
 
-css-what@2.1:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
-  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+css-what@^3.2.1:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
+  integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -3615,21 +3658,21 @@ dompurify@^2.0.12:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.14.tgz#792f72e95bc643999e7ae81baf6e9c6d9de02429"
   integrity sha512-oqcjyCLHLjWugZ6VwK0YfmRND/DFy/CuZhdasmymMfnxbzaaQxBSA1ATZIXWESGDj/nvq1vKLmRa7rTdbGgrmQ==
 
-domutils@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
+domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
@@ -5163,7 +5206,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-he@1.2.x:
+he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -5218,18 +5261,18 @@ html-entities@^1.3.1:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.3.1.tgz#fb9a1a4b5b14c5daba82d3e34c6ae4fe701a0e44"
   integrity sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==
 
-html-minifier@^3.2.3:
-  version "3.5.21"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.21.tgz#d0040e054730e354db008463593194015212d20c"
-  integrity sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==
+html-minifier-terser@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#922e96f1f3bb60832c2634b79884096389b1f054"
+  integrity sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==
   dependencies:
-    camel-case "3.0.x"
-    clean-css "4.2.x"
-    commander "2.17.x"
-    he "1.2.x"
-    param-case "2.1.x"
-    relateurl "0.2.x"
-    uglify-js "3.4.x"
+    camel-case "^4.1.1"
+    clean-css "^4.2.3"
+    commander "^4.1.1"
+    he "^1.2.0"
+    param-case "^3.0.3"
+    relateurl "^0.2.7"
+    terser "^4.6.3"
 
 html-tags@^2.0.0:
   version "2.0.0"
@@ -5241,20 +5284,22 @@ html-tags@^3.1.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
-html-webpack-plugin@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
-  integrity sha1-sBq71yOsqqeze2r0SS69oD2d03s=
+html-webpack-plugin@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.1.tgz#40aaf1b5cb78f2f23a83333999625c20929cda65"
+  integrity sha512-yzK7RQZwv9xB+pcdHNTjcqbaaDZ+5L0zJHXfi89iWIZmb/FtzxhLk0635rmJihcQbs3ZUF27Xp4oWGx6EK56zg==
   dependencies:
-    html-minifier "^3.2.3"
-    loader-utils "^0.2.16"
-    lodash "^4.17.3"
-    pretty-error "^2.0.2"
-    tapable "^1.0.0"
-    toposort "^1.0.0"
+    "@types/html-minifier-terser" "^5.0.0"
+    "@types/tapable" "^1.0.5"
+    "@types/webpack" "^4.41.8"
+    html-minifier-terser "^5.0.1"
+    loader-utils "^1.2.3"
+    lodash "^4.17.20"
+    pretty-error "^2.1.1"
+    tapable "^1.1.3"
     util.promisify "1.0.0"
 
-htmlparser2@^3.10.0, htmlparser2@^3.3.0:
+htmlparser2@^3.10.0, htmlparser2@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -6335,16 +6380,6 @@ loader-utils@1.0.x:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-loader-utils@^0.2.16:
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
-  integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
-    object-assign "^4.0.1"
-
 loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
@@ -6439,7 +6474,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.10:
+lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -6493,10 +6528,12 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lower-case@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
-  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
 
 lru-cache@^4.0.1, lru-cache@^4.1.1:
   version "4.1.5"
@@ -7014,12 +7051,13 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-no-case@^2.2.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
-  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
   dependencies:
-    lower-case "^1.1.1"
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -7174,7 +7212,7 @@ npm-run-path@^4.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@~1.0.1:
+nth-check@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
@@ -7515,12 +7553,13 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-param-case@2.1.x:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
-  integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
+param-case@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
+  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
   dependencies:
-    no-case "^2.2.0"
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -7617,6 +7656,14 @@ parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -8029,13 +8076,13 @@ prettier@^2.1.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
-pretty-error@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
-  integrity sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
+pretty-error@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.2.tgz#be89f82d81b1c86ec8fdfbc385045882727f93b6"
+  integrity sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==
   dependencies:
-    renderkid "^2.0.1"
-    utila "~0.4"
+    lodash "^4.17.20"
+    renderkid "^2.0.4"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -8498,7 +8545,7 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
-relateurl@0.2.x:
+relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
@@ -8609,16 +8656,16 @@ remove-trailing-separator@^1.0.1:
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
-renderkid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.3.tgz#380179c2ff5ae1365c522bf2fcfcff01c5b74149"
-  integrity sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==
+renderkid@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.5.tgz#483b1ac59c6601ab30a7a596a5965cabccfdd0a5"
+  integrity sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==
   dependencies:
-    css-select "^1.1.0"
+    css-select "^2.0.2"
     dom-converter "^0.2"
-    htmlparser2 "^3.3.0"
+    htmlparser2 "^3.10.1"
+    lodash "^4.17.20"
     strip-ansi "^3.0.0"
-    utila "^0.4.0"
 
 repeat-element@^1.1.2:
   version "1.1.3"
@@ -9424,6 +9471,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -10076,7 +10128,7 @@ terser-webpack-plugin@^4.1.0:
     terser "^5.0.0"
     webpack-sources "^1.4.3"
 
-terser@^4.1.2:
+terser@^4.1.2, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
@@ -10204,11 +10256,6 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-toposort@^1.0.0:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
-  integrity sha1-LmhELZ9k7HILjMieZEOsbKqVACk=
-
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -10290,6 +10337,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
+tslib@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -10358,14 +10410,6 @@ ua-parser-js@^0.7.18:
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
   integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
-
-uglify-js@3.4.x:
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"
-  integrity sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==
-  dependencies:
-    commander "~2.19.0"
-    source-map "~0.6.1"
 
 uglify-js@^3.1.4:
   version "3.10.3"
@@ -10572,11 +10616,6 @@ upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
-upper-case@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
-  integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
-
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -10637,7 +10676,7 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-utila@^0.4.0, utila@~0.4:
+utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=


### PR DESCRIPTION
### Related Ticket(s)

Refs #8 

### Description

This PR makes multiple fixes to how the page level chunks are pulled in:

- Change the global import to be imported to the page level chunks
- Update to use the correct version of html-webpack-plugin
- Adding splitChunk configuration
- Fix to pages.js configuration (misconfiguration of the solutions chunk that was overwriting the learn chunk)
- Fix to missing closing tags on the learn template

### Changelog

**Changed**

- Various webpack configuration fixes
