### PR TITLE
chore(webpack): setting up splitchunks to reduce artifact sizes

### DIFF
--- a/config/webpack.config-helper.js
+++ b/config/webpack.config-helper.js
@@ -115,6 +115,8 @@ module.exports = (options) => {
     ...webpackConfig.optimization,
     splitChunks: {
       chunks: 'all',
+      minSize: 30 * 1024,
+      maxSize: 1024 * 1024,
     },
     minimizer: [
       new TerserPlugin({


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This is an attempt to split up the webpack files to see if this increases load performance/script evaluation.

### Changelog

**Changed**

- Webpack config