### PR TITLE
chore(calloutdata): adding feature flag for callout data

### DIFF
--- a/.github/workflows/deploy-ibm-cloud-staging.yml
+++ b/.github/workflows/deploy-ibm-cloud-staging.yml
@@ -22,6 +22,12 @@ jobs:
         run: yarn install
       - name: Grab latest next release
         run: yarn update-next
+      - name: Set env vars
+        uses: ./.github/actions/set-dotenv
+        with:
+          env-file: .env
+        env:
+          DDS_CALLOUT_DATA: true
       - name: Build project
         run: yarn build
       - name: Deploying to IBM Cloud (Staging)

--- a/.github/workflows/deploy-ibm-cloud.yml
+++ b/.github/workflows/deploy-ibm-cloud.yml
@@ -22,6 +22,12 @@ jobs:
         run: yarn install
       - name: Grab latest canary release
         run: yarn update-canary
+      - name: Set env vars
+        uses: ./.github/actions/set-dotenv
+        with:
+          env-file: .env
+        env:
+          DDS_CALLOUT_DATA: true
       - name: Build project
         run: yarn build
       - name: Deploying to IBM Cloud (Canary)
@@ -58,6 +64,7 @@ jobs:
           env-file: .env
         env:
           ENABLE_RTL: true
+          DDS_CALLOUT_DATA: true
       - name: Build project
         run: yarn build
       - name: Deploying to IBM Cloud (Canary - RTL)


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The callout data feature flag was not enabled, so this is adding for the canary and staging deployments in Github Actions.

### Changelog

**Changed**

- Added DDS_CALLOUT_DATA flag for github actions deployment workflows
