### PR TITLE
chore(cloud-foundry): updating to force https only

### DIFF
--- a/manifest-canary.yml
+++ b/manifest-canary.yml
@@ -4,5 +4,6 @@ applications:
     path: ./dist
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-web-components-html-test.mybluemix.net

--- a/manifest-rtl.yml
+++ b/manifest-rtl.yml
@@ -4,5 +4,6 @@ applications:
     path: ./dist
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-web-components-html-rtl.mybluemix.net

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -4,5 +4,6 @@ applications:
     path: ./dist
     memory: 64M
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+    force_https: true
     routes:
       - route: ibmdotcom-web-components-html-staging.mybluemix.net


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This is a configuration change in the manifest files for deployment to cloud foundry, in order to force https only.

### Changelog

**Changed**

- Cloud foundry manifest files
