### PR TITLE
fix(lang): change en-gb to en-uk

### DIFF
--- a/src/layouts/base.hbs
+++ b/src/layouts/base.hbs
@@ -142,7 +142,7 @@
   <link rel="alternate" hrefLang="en-ua" href="{{ htmlWebpackPlugin.options.altlangRootPath }}/index.html?cc=ua&lc=en"/>
   <link rel="alternate" hrefLang="en-ug" href="{{ htmlWebpackPlugin.options.altlangRootPath }}/index.html?cc=ug&lc=en"/>
   <link rel="alternate" hrefLang="en-ae" href="{{ htmlWebpackPlugin.options.altlangRootPath }}/index.html?cc=ae&lc=en"/>
-  <link rel="alternate" hrefLang="en-gb" href="{{ htmlWebpackPlugin.options.altlangRootPath }}/index.html?cc=uk&lc=en"/>
+  <link rel="alternate" hrefLang="en-uk" href="{{ htmlWebpackPlugin.options.altlangRootPath }}/index.html?cc=uk&lc=en"/>
   <link rel="alternate" hrefLang="es-uy" href="{{ htmlWebpackPlugin.options.altlangRootPath }}/index.html?cc=uy&lc=es"/>
   <link rel="alternate" hrefLang="en-uz" href="{{ htmlWebpackPlugin.options.altlangRootPath }}/index.html?cc=uz&lc=en"/>
   <link rel="alternate" hrefLang="es-ve" href="{{ htmlWebpackPlugin.options.altlangRootPath }}/index.html?cc=ve&lc=es"/>


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Adjusting `en-gb` to `en-uk`.

### Changelog

**Changed**

- altlangs
