### PR TITLE
test(e2e): bump pageLoadTimeout for cypress

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -29,6 +29,6 @@ jobs:
           DDS_CALLOUT_DATA: true
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Build the app
-          run: yarn build
+        run: yarn build
       - name: Run e2e tests
         run: yarn test:e2e:local

--- a/tests/e2e/cypress.json
+++ b/tests/e2e/cypress.json
@@ -11,6 +11,6 @@
   "nodeVersion": "system",
   "includeShadowDom": true,
   "testFiles": "**/*.e2e.js",
-  "pageLoadTimeout": 20000,
+  "pageLoadTimeout": 40000,
   "defaultCommandTimeout": 20000
 }


### PR DESCRIPTION
### Related Ticket(s)

Ref https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6325

### Description

Our CI is timing out when running cypress tests, so bumping the timeout amount to accommodate.

### Changelog

**Changed**

- `cypress.json`
