### PR TITLE
fix(workflow): bumping cypress page timeout even more

### DIFF
--- a/tests/e2e/cypress.json
+++ b/tests/e2e/cypress.json
@@ -11,6 +11,6 @@
   "nodeVersion": "system",
   "includeShadowDom": true,
   "testFiles": "**/*.e2e.js",
-  "pageLoadTimeout": 40000,
+  "pageLoadTimeout": 60000,
   "defaultCommandTimeout": 20000
 }


### PR DESCRIPTION
### Related Ticket(s)

Ref https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6325

### Description

This increases the page timeout even more for cypress tests.

### Changelog

**Changed**

- `cypress.json`
