### PR TITLE
test(percy): running percy baseline update for upstream

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -27,8 +27,9 @@ jobs:
           env-file: .env
         env:
           DDS_CALLOUT_DATA: true
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Build the app
         run: yarn build
       - name: Run e2e tests
-        run: yarn test:e2e:local
+        run: PERCY_TOKEN=${{ secrets.PERCY_TOKEN }} yarn test:e2e:local
+      - name: Run e2e tests (upstream)
+        run: PERCY_TOKEN=${{ secrets.PERCY_TOKEN_UPSTREAM }} yarn test:e2e:local


### PR DESCRIPTION
### Related Ticket(s)

Ref https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6325

### Description

The percy projects needed to be split out between the test app repo and upstream. This workflow update will update the baseline for percy for both projects now.

### Changelog

**Changed**

- `percy-update-base.yml`
