### PR TITLE
chore(github-actions): upgrading to ubuntu 20.04

### DIFF
--- a/.github/workflows/deploy-ibm-cloud-staging.yml
+++ b/.github/workflows/deploy-ibm-cloud-staging.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-staging:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/deploy-ibm-cloud.yml
+++ b/.github/workflows/deploy-ibm-cloud.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-canary:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -45,7 +45,7 @@ jobs:
           status: ${{ job.status }}
         if: failure()
   deploy-rtl:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   percy-update:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14.x']


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Per documentation from Github, Ubuntu 16.04 is deprecated. This is upgrading our workflows to 20.04.

https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/

### Changelog

**Changed**

- Github actions workflow files
