### PR TITLE
fix(percy-workflow): fixing the percy update baseline workflow

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -27,9 +27,34 @@ jobs:
           env-file: .env
         env:
           DDS_CALLOUT_DATA: true
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Build the app
         run: yarn build
       - name: Run e2e tests
-        run: PERCY_TOKEN=${{ secrets.PERCY_TOKEN }} yarn test:e2e:local
-      - name: Run e2e tests (upstream)
-        run: PERCY_TOKEN=${{ secrets.PERCY_TOKEN_UPSTREAM }} yarn test:e2e:local
+        run: yarn test:e2e:local
+  percy-update-upstream:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [ '14.x' ]
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Install dependencies
+        run: yarn install
+      - name: Grab latest canary release
+        run: yarn update-canary
+      - name: Set env vars
+        uses: ./.github/actions/set-dotenv
+        with:
+          env-file: .env
+        env:
+          DDS_CALLOUT_DATA: true
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_UPSTREAM }}
+      - name: Build the app
+        run: yarn build
+      - name: Run e2e tests
+        run: yarn test:e2e:local


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The percy baseline isn't getting updated, this is an attempt to fix it for the upstream percy project by separating into two separate jobs.

### Changelog

**Changed**

- `percy-update-base.yml`
