### PR TITLE
chore(housekeeping): remove callout data

### DIFF
--- a/.github/workflows/deploy-ibm-cloud-staging.yml
+++ b/.github/workflows/deploy-ibm-cloud-staging.yml
@@ -26,8 +26,6 @@ jobs:
         uses: ./.github/actions/set-dotenv
         with:
           env-file: .env
-        env:
-          DDS_CALLOUT_DATA: true
       - name: Build project
         run: yarn build
       - name: Deploying to IBM Cloud (Staging)

--- a/.github/workflows/deploy-ibm-cloud.yml
+++ b/.github/workflows/deploy-ibm-cloud.yml
@@ -26,8 +26,6 @@ jobs:
         uses: ./.github/actions/set-dotenv
         with:
           env-file: .env
-        env:
-          DDS_CALLOUT_DATA: true
       - name: Build project
         run: yarn build
       - name: Deploying to IBM Cloud (Canary)
@@ -64,7 +62,6 @@ jobs:
           env-file: .env
         env:
           ENABLE_RTL: true
-          DDS_CALLOUT_DATA: true
       - name: Build project
         run: yarn build
       - name: Deploying to IBM Cloud (Canary - RTL)

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           env-file: .env
         env:
-          DDS_CALLOUT_DATA: true
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Build the app
         run: yarn build
@@ -52,7 +51,6 @@ jobs:
         with:
           env-file: .env
         env:
-          DDS_CALLOUT_DATA: true
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_UPSTREAM }}
       - name: Build the app
         run: yarn build

--- a/src/pages/services/services.hbs
+++ b/src/pages/services/services.hbs
@@ -84,12 +84,6 @@
 				</div>
 			</div>
 
-			<dds-callout-data>
-				<dds-callout-data-heading>51%</dds-callout-data-heading>
-				<dds-callout-data-copy>Lorem ipsum dolor sit amet</dds-callout-data-copy>
-				<dds-callout-data-source>Dolor sit amet</dds-callout-data-source>
-			</dds-callout-data>
-
 			<a name="2" data-title="Content Block Media"></a>
 			<div class="bx--grid">
 				<div class="bx--row">

--- a/src/pages/services/services.js
+++ b/src/pages/services/services.js
@@ -16,9 +16,6 @@ import '@carbon/ibmdotcom-web-components/es/components/content-block-media';
 import '@carbon/ibmdotcom-web-components/es/components/content-block-simple';
 import '@carbon/ibmdotcom-web-components/es/components/content-block-segmented';
 
-// Callout Data
-import '@carbon/ibmdotcom-web-components/es/components/callout-data';
-
 // Callout with media
 import '@carbon/ibmdotcom-web-components/es/components/callout-with-media';
 


### PR DESCRIPTION
### Related Ticket(s)
https://app.zenhub.com/workspaces/carbon-for-ibmcom-5d449f3642eb1962336cbe52/issues/carbon-design-system/carbon-for-ibm-dotcom/6183

### Description
Removing `CalloutData` from Services page as it is now deprecated.

### Changelog

**Removed**

- `CalloutData` from Services page
