### PR TITLE
test(e2e): add ignore for cypress ResizeObserver exception

### DIFF
--- a/tests/e2e/cypress/support/index.js
+++ b/tests/e2e/cypress/support/index.js
@@ -10,6 +10,16 @@ import '@percy/cypress';
 
 import './commands';
 
+// Ignore ResizeObserver exceptions
+Cypress.on('uncaught:exception', (err) => {
+  const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
+
+  /* returning false here prevents Cypress from failing the test */
+  if (resizeObserverLoopErrRe.test(err.message)) {
+    return false;
+  }
+});
+
 // Workaround, @percy/cypress was not properly loading in PercyDOM
 if (window) {
   window.PercyDOM = {


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Noticing some errors happening in e2e testing:

![image](https://user-images.githubusercontent.com/1641214/140548034-c12c7bb7-d555-4d0f-8b97-c8e082655477.png)

According to Cypress team, this is something we can safely ignore. Adding an exception so that tests can pass:

https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded

### Changelog

**Changed**

- Added in cypress support an ignore for `ResizeObserver` exception
