### PR TITLE
chore(github-actions): add dispatch trigger for percy baseline update

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  repository_dispatch:
+    types: [deploy-canary]
 
 jobs:
   percy-update:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

The trigger to update the percy baseline with every update to `Carbon for IBM.com` was not in place, so the baseline was getting stale. 

This should add the trigger so every time the library is updated, this baseline for the test app gets updated.

### Changelog

**Changed**

- Add dispatch trigger for `percy-update-base.yml`
