### PR TITLE
fix(leadspace): proper use of leadspace action slot

### DIFF
--- a/src/pages/example-page-a/example-page-a.hbs
+++ b/src/pages/example-page-a/example-page-a.hbs
@@ -3,7 +3,7 @@
   <dds-leadspace type="centered" alt="Image text" default-src="../assets/images/leadspace/fpo--leadspace--1584x560--004.jpg">
     <dds-leadspace-heading>Lead space title</dds-leadspace-heading>
     Use this area for a short line of copy to support the title
-    <dds-button-group>
+    <dds-button-group slot="action">
       <dds-button-group-item href="https://example.com">
         Button 1
         <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">

--- a/src/pages/example-page-c/example-page-c.hbs
+++ b/src/pages/example-page-c/example-page-c.hbs
@@ -3,7 +3,7 @@
   <dds-leadspace alt="Image text" default-src="../assets/images/leadspace/leadspaceMax.jpg">
     <dds-leadspace-heading>Lead space title</dds-leadspace-heading>
     Use this area for a short line of copy to support the title
-    <dds-button-group>
+    <dds-button-group slot="action">
       <dds-button-group-item href="https://example.com">
         Button 1
         <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" slot="icon">


### PR DESCRIPTION
### Related Ticket(s)

Fixes an issue with use of the `<dds-leadspace>` component that came up in https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9619

### Description

In a couple of the examples in this repo, the `<dds-leadspace>` component was used without specifying the `slot="action"` for the `<dds-button-group>` components that are slotted in under the `<dds-leadspace>` component. This PR fixes that usage to be consistent with the required use.

### Changelog

**Changed**

- Example page a and c explicitly specify the action slot for their button group child components of the leadspace component
